### PR TITLE
feat: copier update to parent template v0.1.5

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.1.4
+_commit: v0.1.5
 _src_path: gh:natescherer/postmodern-docker-container-copiertemplate
 author_name: Nate Scherer
 developer_platform: GitHub

--- a/renovate.json5
+++ b/renovate.json5
@@ -14,11 +14,13 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^Dockerfile$"],
-      "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sENV .*?_VERSION=\"(?<currentValue>.*)\"\\s"
+      "fileMatch": [
+        "(^|/|\\.)([Dd]ocker|[Cc]ontainer)file$",
+        "(^|/)([Dd]ocker|[Cc]ontainer)file[^/]*$"
       ],
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s(?:ENV|ARG)\\s+[A-Za-z0-9_]+?_VERSION[ =][\"']?(?<currentValue>.+?)[\"']?\\s"
+      ]
     }
   ]
 }

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:24.04
 
-# renovate: datasource=repology depName=ubuntu_24_04/nano versioning=deb
-ENV NANO_VERSION=7.2
+# renovate: datasource=repology depName=ubuntu_24_04/nano versioning=loose
+ENV NANO_VERSION=7.2-2ubuntu0.1
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \


### PR DESCRIPTION
Copier has applied updates from parent template v0.1.5.

Review and push any needed changes to the `copier-template-update-v0.1.5` branch.