### PR TITLE
feat: copier update to parent template v0.1.6

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.1.5
+_commit: v0.1.6
 _src_path: gh:natescherer/postmodern-docker-container-copiertemplate
 author_name: Nate Scherer
 developer_platform: GitHub

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -10,4 +10,4 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-CMD ["nano --version"]
+CMD ["nano", "--version"]


### PR DESCRIPTION
Copier has applied updates from parent template v0.1.6.

Review and push any needed changes to the `copier-template-update-v0.1.6` branch.