### PR TITLE
feat: copier update to parent template v0.1.8

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.1.7
+_commit: v0.1.8
 _src_path: gh:natescherer/postmodern-docker-container-copiertemplate
 author_name: Nate Scherer
 developer_platform: GitHub

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,5 +9,10 @@
       "release-type": "simple",
       "changelog-path": "CHANGELOG.md"
     }
-  }
+  },
+  "changelog-sections": [
+    { "type": "feat", "section": "Features", "hidden": false },
+    { "type": "fix", "section": "Bug Fixes", "hidden": false },
+    { "type": "chore", "section": "Miscellaneous", "hidden": false }
+  ]
 }


### PR DESCRIPTION
Copier has applied updates from parent template v0.1.8.

Review and push any needed changes to the `copier-template-update-v0.1.8` branch.