### PR TITLE
feat: copier update to parent template v0.1.9

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.1.8
+_commit: v0.1.9
 _src_path: gh:natescherer/postmodern-docker-container-copiertemplate
 author_name: Nate Scherer
 developer_platform: GitHub

--- a/.github/workflows/ci_docker_build_and_push.yml
+++ b/.github/workflows/ci_docker_build_and_push.yml
@@ -1,8 +1,9 @@
-name: "CI: Build/Push Docker Image on Push to main"
+name: "CI: Build/Push Current State of main"
 
 on:
   push:
     branches: main
+    paths: src/**
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/release_docker_build_and_push.yml
+++ b/.github/workflows/release_docker_build_and_push.yml
@@ -1,4 +1,4 @@
-name: "Release: Build/Push Docker Image on New Tag"
+name: "Release: Build/Push on Release Tag"
 
 on:
   push:


### PR DESCRIPTION
Copier has applied updates from parent template v0.1.9.

Review and push any needed changes to the `copier-template-update-v0.1.9` branch.