### PR TITLE
feat: copier update to parent template v0.1.10

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.1.9
+_commit: v0.1.10
 _src_path: gh:natescherer/postmodern-docker-container-copiertemplate
 author_name: Nate Scherer
 developer_platform: GitHub

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,0 @@
-FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
-
-# Set default shell for RUN commands to bash
-SHELL ["/bin/bash", "-c"]
-
-# Copy support files into image
-COPY library/* /opt/devcontainer/

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,18 +1,7 @@
 {
   "name": "postmodern-tools",
-  "build": {
-    "dockerfile": "Dockerfile",
-    "context": ".",
-    "args": {
-      "NONROOT_USER": "vscode"
-    }
-  },
-  "remoteUser": "root", // Copier (really Python shutil) can't deal with bind-mounted files being owned as root on Windows hosts
+  "image": "ghcr.io/natescherer/postmodern-tools-container:latest@sha256:f56e2b15bc906e071d9db7ccbc51e44ff0c218adea61ce35eaf4b8049f946a3e",
   "features": {
-    "ghcr.io/natescherer/devcontainers-custom-features/hypermodern-python:1": {
-      "versions": "3.12",
-      "requirementsFile": "/opt/devcontainer/requirements.txt"
-    },
     "ghcr.io/trunk-io/devcontainer-feature/trunk:1": "latest",
     "ghcr.io/devcontainers-extra/features/renovate-cli:2": {}
   },

--- a/.devcontainer/library/requirements.txt
+++ b/.devcontainer/library/requirements.txt
@@ -1,8 +1,0 @@
-copier-templates-extensions>=0.3.0,<1
-githubkit>=0.11.8,<1
-invoke>=2.2.0,<3
-jinja2-shell-extension>=2.0.1,<3
-jinja2-time>=0.2.0,<1
-requests>=2.32.3,<3
-rich>=13.8.0,<14
-unicode-slugify>=0.1.5,<1

--- a/.github/workflows/update_copier_parent_template.yml
+++ b/.github/workflows/update_copier_parent_template.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Install Copier & Dependencies
-        run: pip install -r .devcontainer/library/requirements.txt
+        run: pip install -r .github/workflows/update_copier_parent_template_deps/requirements.txt
       - name: Get New Template Version
         id: get_ver
         shell: pwsh

--- a/.github/workflows/update_copier_parent_template_deps/requirements.txt
+++ b/.github/workflows/update_copier_parent_template_deps/requirements.txt
@@ -1,0 +1,9 @@
+copier==9.4.1
+copier-templates-extensions==0.3.0
+githubkit==0.12.4
+invoke==2.2.0
+jinja2-shell-extension==2.1.0
+jinja2-time==0.2.0
+requests==2.32.3
+rich==13.9.4
+unicode-slugify==0.1.5

--- a/.trunk/configs/cspell.yaml
+++ b/.trunk/configs/cspell.yaml
@@ -35,10 +35,11 @@ words:
   # GitHub Username
   - natescherer
   # Code Terms
-  - pscore
+  - infisical
   - pydoclint
   - pyupgrade
-  - infisical
+  - pscore
+  - taplo
 patterns:
   - name: devcontainer-features
     pattern: "\"features\": {(.|\\n)*}"

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -21,12 +21,14 @@ lint:
     - osv-scanner
     - trufflehog
   enabled:
-    - actionlint@1.7.5
+    - actionlint@1.7.6
     - cspell@8.17.1
     - git-diff-check
     - hadolint@2.12.1-beta
+    - markdown-link-check@3.13.6
     - markdownlint@0.43.0
     - prettier@3.4.2
+    - renovate@39.92.0
     - yamllint@1.35.1
   ignore:
     - linters: [ALL]

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Contributions and bug reports are gladly accepted! Please see [CONTRIBUTING.md](
 ## Contributors
 
 <!-- spell-checker:disable -->
+<!-- markdown-link-check-disable -->
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable -->
@@ -63,6 +64,7 @@ Contributions and bug reports are gladly accepted! Please see [CONTRIBUTING.md](
 <!-- prettier-ignore-end -->
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
+<!-- markdown-link-check-enable -->
 <!-- spell-checker:enable -->
 
 This project follows the [all-contributors](https://allcontributors.org) specification.

--- a/renovate.json5
+++ b/renovate.json5
@@ -2,21 +2,27 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "dependencyDashboard": false,
   "extends": ["config:recommended"],
-  // Per-provider config below
   "copier": {
     // Copier template updates are handled via dedicated GitHub Actions Workflow/Azure DevOps pipeline
     "enabled": false
   },
-  // Package rules below
+  "docker": {
+    "pinDigests": true
+  },
   "packageRules": [
+    {
+      "description": "Don't pin digests in devcontainer.json because it's not supported in features",
+      "matchManagers": ["devcontainer"],
+      "pinDigests": false
+    }
   ],
   // Custom managers below
   "customManagers": [
     {
       "customType": "regex",
       "fileMatch": [
-        "(^|/|\\.)([Dd]ocker|[Cc]ontainer)file$",
-        "(^|/)([Dd]ocker|[Cc]ontainer)file[^/]*$"
+        "(^|/|\\.)([Dd]ocker|[Cc]ontainer)file$", // cspell:disable-line
+        "(^|/)([Dd]ocker|[Cc]ontainer)file[^/]*$" // cspell:disable-line
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s(?:ENV|ARG)\\s+[A-Za-z0-9_]+?_VERSION[ =][\"']?(?<currentValue>.+?)[\"']?\\s"

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,9 +1,5 @@
-<<<<<<< before updating
-FROM ubuntu:24.04
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-=======
 FROM ubuntu:24.04@sha256:80dd3c3b9c6cecb9f1667e9290b3bc61b78c2678c02cbdae5f0fea92cc6734ab
->>>>>>> after updating
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # NOTE 1: As of 2025/01/07, the only way to install Git Credential Manager on arm64 Linux is as a .NET Tool.
 # Once arm64 deb packages are released, this install method should be changed.

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,5 +1,9 @@
+<<<<<<< before updating
 FROM ubuntu:24.04
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+=======
+FROM ubuntu:24.04@sha256:80dd3c3b9c6cecb9f1667e9290b3bc61b78c2678c02cbdae5f0fea92cc6734ab
+>>>>>>> after updating
 
 # NOTE 1: As of 2025/01/07, the only way to install Git Credential Manager on arm64 Linux is as a .NET Tool.
 # Once arm64 deb packages are released, this install method should be changed.


### PR DESCRIPTION
Copier has applied updates from parent template v0.1.10.

Review and push any needed changes to the `copier-template-update-v0.1.10` branch.