### PR TITLE
feat: copier update to parent template v0.1.11

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.1.10
+_commit: v0.1.11
 _src_path: gh:natescherer/postmodern-docker-container-copiertemplate
 author_name: Nate Scherer
 developer_platform: GitHub

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# The below config is for shfmt to apply Google's shell style guide (or as close to it as the tool can get)
+[*.sh]
+# like -i=2
+indent_style = space
+indent_size = 2
+# like -bn
+binary_next_line   = true
+# --case-indent
+switch_case_indent = true

--- a/.trunk/configs/.shellcheckrc
+++ b/.trunk/configs/.shellcheckrc
@@ -1,0 +1,7 @@
+enable=all
+source-path=SCRIPTDIR
+disable=SC2154
+
+# If you're having issues with shellcheck following source, disable the errors via:
+# disable=SC1090
+# disable=SC1091

--- a/.trunk/configs/cspell.yaml
+++ b/.trunk/configs/cspell.yaml
@@ -35,11 +35,13 @@ words:
   # GitHub Username
   - natescherer
   # Code Terms
+  - gosu
   - infisical
   - pydoclint
   - pyupgrade
   - pypa
   - pscore
+  - shfmt
   - taplo
 patterns:
   - name: devcontainer-features

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -29,6 +29,8 @@ lint:
     - markdownlint@0.43.0
     - prettier@3.4.2
     - renovate@39.92.0
+    - shellcheck@0.10.0
+    - shfmt@3.6.0
     - yamllint@1.35.1
   ignore:
     - linters: [ALL]

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:24.04@sha256:80dd3c3b9c6cecb9f1667e9290b3bc61b78c2678c02cbdae5f0fea92cc6734ab
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+<<<<<<< before updating
 
 # NOTE 1: As of 2025/01/07, the only way to install Git Credential Manager on arm64 Linux is as a .NET Tool.
 # Once arm64 deb packages are released, this install method should be changed.
@@ -26,9 +27,25 @@ ENV RENOVATE_INVOKE_VERSION=2.2.0
 ENV RENOVATE_PIPX_VERSION=1.7.1
 # renovate: datasource=repology depName=ubuntu_24_04/python3.12 versioning=loose
 ENV RENOVATE_PYTHON312_VERSION=3.12.3-1ubuntu0.3
+=======
+
+# renovate: datasource=repology depName=ubuntu_24_04/ca-certificates versioning=loose
+ENV RENOVATE_CA_CERTIFICATES_VERSION=20240203
+
+# renovate: datasource=repology depName=ubuntu_24_04/curl versioning=loose
+ENV RENOVATE_CURL_VERSION=8.5.0-2ubuntu10.6
+
+# renovate: datasource=github-releases depName=tianon/gosu
+ENV RENOVATE_GOSU_VERSION=1.17
+
+# renovate: datasource=repology depName=ubuntu_24_04/nano versioning=loose
+ENV RENOVATE_NANO_VERSION=7.2-2ubuntu0.1
+
+>>>>>>> after updating
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
+<<<<<<< before updating
     curl="${RENOVATE_CURL_VERSION}" \
     dotnet-sdk-8.0="${RENOVATE_DOTNET_VERSION}" \
     git="${RENOVATE_GIT_VERSION}" \
@@ -47,3 +64,21 @@ RUN curl -fsSL -O --output-dir /usr/local/bin https://github.com/pypa/pipx/relea
     && python /usr/local/bin/pipx.pyz install --global --pip-args="--no-cache-dir" copier==${RENOVATE_COPIER_VERSION} \
     && sed -e 's/#.*//' requirements.txt | xargs python /usr/local/bin/pipx.pyz inject --global --pip-args="--no-cache-dir" copier \
     && python /usr/local/bin/pipx.pyz inject --global --pip-args="--no-cache-dir" --include-apps copier invoke==${RENOVATE_INVOKE_VERSION}
+=======
+    ca-certificates="${RENOVATE_CA_CERTIFICATES_VERSION}" \
+    curl="${RENOVATE_CURL_VERSION}" \
+    nano="${RENOVATE_NANO_VERSION}" \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN DPKG_ARCH="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
+	&& curl -fsSL -o gosu --output-dir /usr/local/bin "https://github.com/tianon/gosu/releases/download/$RENOVATE_GOSU_VERSION/gosu-$DPKG_ARCH" \
+	&& chmod +x /usr/local/bin/gosu \
+	&& gosu --version \
+	&& gosu nobody true
+
+WORKDIR /srv/dockercontainer
+COPY entrypoint.sh ./
+ENTRYPOINT ["/srv/dockercontainer/entrypoint.sh"]
+CMD ["nano", "--version"]
+>>>>>>> after updating

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,6 +1,5 @@
 FROM ubuntu:24.04@sha256:80dd3c3b9c6cecb9f1667e9290b3bc61b78c2678c02cbdae5f0fea92cc6734ab
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-<<<<<<< before updating
 
 # NOTE 1: As of 2025/01/07, the only way to install Git Credential Manager on arm64 Linux is as a .NET Tool.
 # Once arm64 deb packages are released, this install method should be changed.

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -8,6 +8,8 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # NOTE 2: As of 2025/01/08, the only supported way to get pipx 1.5.0+ (which has the needed --global) option
 # on Ubuntu 24.04 is to install via zipapp
 
+# renovate: datasource=repology depName=ubuntu_24_04/ca-certificates versioning=loose
+ENV RENOVATE_CA_CERTIFICATES_VERSION=20240203
 # renovate: datasource=pypi depName=copier
 ENV RENOVATE_COPIER_VERSION=9.4.1
 # renovate: datasource=repology depName=ubuntu_24_04/curl versioning=loose
@@ -21,31 +23,18 @@ ENV RENOVATE_DOTNET_VERSION=8.0.111-0ubuntu1~24.04.1
 ENV RENOVATE_GIT_VERSION=1:2.43.0-1ubuntu7.1
 # renovate: datasource=nuget depName=git-credential-manager
 ENV RENOVATE_GCM_VERSION=2.6.0
+# renovate: datasource=github-releases depName=tianon/gosu
+ENV RENOVATE_GOSU_VERSION=1.17
 # renovate: datasource=pypi depName=invoke
 ENV RENOVATE_INVOKE_VERSION=2.2.0
 # renovate: datasource=github-releases depName=pypa/pipx
 ENV RENOVATE_PIPX_VERSION=1.7.1
 # renovate: datasource=repology depName=ubuntu_24_04/python3.12 versioning=loose
 ENV RENOVATE_PYTHON312_VERSION=3.12.3-1ubuntu0.3
-=======
-
-# renovate: datasource=repology depName=ubuntu_24_04/ca-certificates versioning=loose
-ENV RENOVATE_CA_CERTIFICATES_VERSION=20240203
-
-# renovate: datasource=repology depName=ubuntu_24_04/curl versioning=loose
-ENV RENOVATE_CURL_VERSION=8.5.0-2ubuntu10.6
-
-# renovate: datasource=github-releases depName=tianon/gosu
-ENV RENOVATE_GOSU_VERSION=1.17
-
-# renovate: datasource=repology depName=ubuntu_24_04/nano versioning=loose
-ENV RENOVATE_NANO_VERSION=7.2-2ubuntu0.1
-
->>>>>>> after updating
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
-<<<<<<< before updating
+    ca-certificates="${RENOVATE_CA_CERTIFICATES_VERSION}" \
     curl="${RENOVATE_CURL_VERSION}" \
     dotnet-sdk-8.0="${RENOVATE_DOTNET_VERSION}" \
     git="${RENOVATE_GIT_VERSION}" \
@@ -57,19 +46,13 @@ RUN apt-get update \
 
 RUN dotnet tool install --tool-path /usr/local/bin git-credential-manager --version ${RENOVATE_GCM_VERSION}
 
-WORKDIR /usr/src/app
+WORKDIR /srv/dockercontainer
 COPY requirements.txt ./
 RUN curl -fsSL -O --output-dir /usr/local/bin https://github.com/pypa/pipx/releases/download/${RENOVATE_PIPX_VERSION}/pipx.pyz \
     && echo 'alias pipx="python /usr/local/bin/pipx.pyz"' >> ~/.bash_aliases \
     && python /usr/local/bin/pipx.pyz install --global --pip-args="--no-cache-dir" copier==${RENOVATE_COPIER_VERSION} \
     && sed -e 's/#.*//' requirements.txt | xargs python /usr/local/bin/pipx.pyz inject --global --pip-args="--no-cache-dir" copier \
     && python /usr/local/bin/pipx.pyz inject --global --pip-args="--no-cache-dir" --include-apps copier invoke==${RENOVATE_INVOKE_VERSION}
-=======
-    ca-certificates="${RENOVATE_CA_CERTIFICATES_VERSION}" \
-    curl="${RENOVATE_CURL_VERSION}" \
-    nano="${RENOVATE_NANO_VERSION}" \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
 
 RUN DPKG_ARCH="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
 	&& curl -fsSL -o gosu --output-dir /usr/local/bin "https://github.com/tianon/gosu/releases/download/$RENOVATE_GOSU_VERSION/gosu-$DPKG_ARCH" \
@@ -77,8 +60,7 @@ RUN DPKG_ARCH="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
 	&& gosu --version \
 	&& gosu nobody true
 
-WORKDIR /srv/dockercontainer
 COPY entrypoint.sh ./
+
 ENTRYPOINT ["/srv/dockercontainer/entrypoint.sh"]
-CMD ["nano", "--version"]
->>>>>>> after updating
+CMD ["bash", "-c"]

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -9,7 +9,9 @@ usermod -o -u "${NEW_UID}" "${ENTRYPOINT_USERNAME}" 1>/dev/null  # Modify the us
 groupmod -o -g "${NEW_GID}" "${ENTRYPOINT_USERNAME}" 1>/dev/null # Modify the group id.
 
 printf "User '%s' is running with the following IDs:\n" "${ENTRYPOINT_USERNAME}"
-printf "\tUID: %s\n" $(id -u "${ENTRYPOINT_USERNAME}")
-printf "\tGID: %s\n" $(id -u "${ENTRYPOINT_USERNAME}")
+CURRENT_UID="$(id -u "${ENTRYPOINT_USERNAME}")"
+printf "\tUID: %s\n" "${CURRENT_UID}"
+CURRENT_GID="$(id -g "${ENTRYPOINT_USERNAME}")"
+printf "\tGID: %s\n" "${CURRENT_GID}"
 
 gosu "${ENTRYPOINT_USERNAME}" "$@" # Run the command the entrypoint was called with as the custom user.

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+ENTRYPOINT_USERNAME=ubuntu
+
+NEW_UID="${HOST_UID:-$(id -u "${ENTRYPOINT_USERNAME}")}" # Use the environment variable value or default (1000) if variable is not set.
+NEW_GID=${HOST_GID:-$(id -g "${ENTRYPOINT_USERNAME}")}   # Use the environment variable value or default (1000) if variable is not set.
+
+usermod -o -u "${NEW_UID}" "${ENTRYPOINT_USERNAME}" 1>/dev/null  # Modify the user id.
+groupmod -o -g "${NEW_GID}" "${ENTRYPOINT_USERNAME}" 1>/dev/null # Modify the group id.
+
+printf "User '%s' is running with the following IDs:\n" "${ENTRYPOINT_USERNAME}"
+printf "\tUID: %s\n" $(id -u "${ENTRYPOINT_USERNAME}")
+printf "\tGID: %s\n" $(id -u "${ENTRYPOINT_USERNAME}")
+
+gosu "${ENTRYPOINT_USERNAME}" "$@" # Run the command the entrypoint was called with as the custom user.


### PR DESCRIPTION
Copier has applied updates from parent template v0.1.11.

Review and push any needed changes to the `copier-template-update-v0.1.11` branch.